### PR TITLE
Removed precompiled binary and added build to install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,3 +5,4 @@ go get -u github.com/olekukonko/tablewriter
 go get -u github.com/chzyer/readline
 go get -u github.com/common-nighthawk/go-figure
 go get -u github.com/gobuffalo/packr
+go build snowcrash.go


### PR DESCRIPTION
I ran into an issue when trying to use this for the first time. I assumed when I ran the install script it would compile the binary, but there is a precompiled binary provided. The issue is that the binary contains the author's path for templates and it would cause a PACKR error. I've removed the precompiled binary and added a go build to the install script. 


![image](https://user-images.githubusercontent.com/854881/86814820-841e2300-c047-11ea-8292-0ca426594385.png)
