### PR TITLE
Fix missing payloads and remove one

### DIFF
--- a/snowcrash.go
+++ b/snowcrash.go
@@ -192,8 +192,8 @@ func random_string(n int) string{
 
 func generate_payload(payload_name string, sleep_interval string, 
 					out string, stdout bool){
-	available_payloads := []string{"cmd_exec", "reverse_shell", "custom", 
-									"exfiltrate", "memexec"}
+	available_payloads := []string{"cmd_exec", "reverse_shell", "custom",                                                                                                                                                 
+                                                                        "download_exec", "memexec", "shutdown", "forkbomb"}
     if (! contains(available_payloads, payload_name)){
         print_error("No such payload: "+payload_name)
         os.Exit(0)


### PR DESCRIPTION
Payloads `download_exec`, `shutdown`, `forkbomb` was missing and the payload `exfiltrate` was available but no action was available for this one